### PR TITLE
🐞 fix: 修复前端渲染bug

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -35,9 +35,11 @@ export default function Home() {
   const [shortUrl, setShortUrl] = useState<string>("");
   const router = useRouter();
 
-  if (!isAuth) {
-    router.push("/auth/login");
-  }
+  useEffect(() => {
+    if (!isAuth) {
+      router.push("/auth/login");
+    }
+  }, [router, isAuth]);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),


### PR DESCRIPTION
根据React的规则，不能在渲染过程中执行导航操作，因为这会导致状态更新。
使用 useEffect 钩子重构未认证用户重定向逻辑。